### PR TITLE
Update kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:260.0.0-slim
 
-RUN apt-get update && apt-get install -y kubectl=1.15.3-00 --no-install-recommends \
+RUN apt-get update && apt-get install -y kubectl=1.17.2-00 --no-install-recommends \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Got a problem with building Dockerfile:
```
E: Version '1.15.3-00' for 'kubectl' was not found
```