### PR TITLE
fix image name comparison and keep container id

### DIFF
--- a/internal/worker/filter.go
+++ b/internal/worker/filter.go
@@ -65,8 +65,8 @@ func existsInCluster(c Catalog, d Digest, name string) bool {
 		// if image specified in container_id in k8s manifest
 		// compare id instead of the tag name
 		if strings.Contains(repo.ImageName, "@sha256") {
-			containerId := "sha256:" + repo.Tag
-			if containerId == d.Name {
+			containerID := "sha256:" + repo.Tag
+			if containerID == d.Name {
 				return true
 			}
 		}

--- a/internal/worker/filter_test.go
+++ b/internal/worker/filter_test.go
@@ -35,7 +35,7 @@ func TestExistsInCluster(t *testing.T) {
 			Tag:            []string{"master.6d902732dc8c0e19725eaa40c7a860a4c02ef406"},
 			TimeCreatedMs:  "1556399434238",
 			TimeUploadedMs: "1556399443871",
-		}, "webapp", false},
+		}, "mygcp-project/mycorp/webapp", false},
 		{Catalog{
 			Repositories: []Repository{
 				{
@@ -56,7 +56,7 @@ func TestExistsInCluster(t *testing.T) {
 			Tag:            []string{"master.abc", "latest"},
 			TimeCreatedMs:  "1556399434238",
 			TimeUploadedMs: "1556399443871",
-		}, "webapp", true},
+		}, "mygcp-project/mycorp/webapp", true},
 		{Catalog{
 			Repositories: []Repository{
 				{
@@ -77,7 +77,7 @@ func TestExistsInCluster(t *testing.T) {
 			Tag:            []string{"master.abc", "latest"},
 			TimeCreatedMs:  "1556399434238",
 			TimeUploadedMs: "1556399443871",
-		}, "webapp", false},
+		}, "mygcp-project/mycorp/webapp", false},
 		{Catalog{
 			Repositories: []Repository{
 				{
@@ -98,7 +98,7 @@ func TestExistsInCluster(t *testing.T) {
 			Tag:            []string{""},
 			TimeCreatedMs:  "1556399434238",
 			TimeUploadedMs: "1556399443871",
-		}, "mysvc", false},
+		}, "mygcp-project/mycorp/mysvc", false},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
ImageName from cluster does not container repository path.
But, name from container registry contains path.
So, adjust these format.

Add support that image spacified in container id (digest begining with `sha256:`) in kubernetes manifest.