### PR TITLE
Add `--protect-tag-regex` flag to cleanup command

### DIFF
--- a/internal/worker/filter_test.go
+++ b/internal/worker/filter_test.go
@@ -130,3 +130,47 @@ func Test_filterCatalog(t *testing.T) {
 		})
 	}
 }
+
+func Test_protected(t *testing.T) {
+	tables := []struct {
+		s string
+		d Digest
+		z bool
+	}{
+		{"^release-",
+		Digest{
+			ImageSizeBytes: "29905102",
+			LayerID:        "",
+			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+			Tag:            []string{"release-20201118-123456"},
+			TimeCreatedMs:  "1556399434238",
+			TimeUploadedMs: "1556399443871",
+		}, true},
+		{"^release-",
+		Digest{
+			ImageSizeBytes: "29905102",
+			LayerID:        "",
+			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+			Tag:            []string{"test-6ef75b0"},
+			TimeCreatedMs:  "1556399434238",
+			TimeUploadedMs: "1556399443871",
+		}, false},
+		{"^v\\d+\\.\\d+\\.\\d+$",
+		Digest{
+			ImageSizeBytes: "29905102",
+			LayerID:        "",
+			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+			Tag:            []string{"v1.2.3"},
+			TimeCreatedMs:  "1556399434238",
+			TimeUploadedMs: "1556399443871",
+		}, true},
+	}
+	for _, table := range tables {
+		res := protected(table.s, table.d)
+		diff := cmp.Diff(res, table.z)
+		if diff != "" {
+			t.Fatalf("protected mismatch (-want +got):\n%v", diff)
+		}
+	}
+}
+

--- a/internal/worker/filter_test.go
+++ b/internal/worker/filter_test.go
@@ -138,32 +138,32 @@ func Test_protected(t *testing.T) {
 		z bool
 	}{
 		{"^release-",
-		Digest{
-			ImageSizeBytes: "29905102",
-			LayerID:        "",
-			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
-			Tag:            []string{"release-20201118-123456"},
-			TimeCreatedMs:  "1556399434238",
-			TimeUploadedMs: "1556399443871",
-		}, true},
+			Digest{
+				ImageSizeBytes: "29905102",
+				LayerID:        "",
+				MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+				Tag:            []string{"release-20201118-123456"},
+				TimeCreatedMs:  "1556399434238",
+				TimeUploadedMs: "1556399443871",
+			}, true},
 		{"^release-",
-		Digest{
-			ImageSizeBytes: "29905102",
-			LayerID:        "",
-			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
-			Tag:            []string{"test-6ef75b0"},
-			TimeCreatedMs:  "1556399434238",
-			TimeUploadedMs: "1556399443871",
-		}, false},
+			Digest{
+				ImageSizeBytes: "29905102",
+				LayerID:        "",
+				MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+				Tag:            []string{"test-6ef75b0"},
+				TimeCreatedMs:  "1556399434238",
+				TimeUploadedMs: "1556399443871",
+			}, false},
 		{"^v\\d+\\.\\d+\\.\\d+$",
-		Digest{
-			ImageSizeBytes: "29905102",
-			LayerID:        "",
-			MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
-			Tag:            []string{"v1.2.3"},
-			TimeCreatedMs:  "1556399434238",
-			TimeUploadedMs: "1556399443871",
-		}, true},
+			Digest{
+				ImageSizeBytes: "29905102",
+				LayerID:        "",
+				MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+				Tag:            []string{"v1.2.3"},
+				TimeCreatedMs:  "1556399434238",
+				TimeUploadedMs: "1556399443871",
+			}, true},
 	}
 	for _, table := range tables {
 		res := protected(table.s, table.d)
@@ -173,4 +173,3 @@ func Test_protected(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/worker/structs.go
+++ b/internal/worker/structs.go
@@ -43,14 +43,15 @@ type ListResponse struct {
 
 // Config is our application config for filtering, listing, cleaning
 type Config struct {
-	CredsFile      string   // path of credentials json file
-	RepoFilter     []string // list of regions we want to check
-	KeepTags       int
-	RetentionDays  int
-	KubeconfigPath string
-	RegistryURL    string
-	SortBy         string
-	DryRun         bool
+	CredsFile       string   // path of credentials json file
+	RepoFilter      []string // list of regions we want to check
+	KeepTags        int
+	RetentionDays   int
+	KubeconfigPath  string
+	RegistryURL     string
+	SortBy          string
+	ProtectTagRegex string
+	DryRun          bool
 }
 
 // FilteredList holds list of tags that were already filtered out


### PR DESCRIPTION
I want to protect some pattern of tag (e.g. '^release-'). So, I added new flag `--protect-tag-regex` to cleanup commmand.